### PR TITLE
Adapt SwiftSyntax repository URL

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,10 +3,10 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
-        "version" : "510.0.1"
+        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
+        "version" : "510.0.3"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/apple/swift-syntax.git",
+            url: "https://github.com/swiftlang/swift-syntax.git",
             "509.0.0"..<"511.0.0"
         )
     ],


### PR DESCRIPTION
```
'swift-macro-testing' dependency on 'https://github.com/apple/swift-syntax' conflicts with dependency on 'https://github.com/swiftlang/swift-syntax.git' which has the same identity 'swift-syntax'. this will be escalated to an error in future versions of SwiftPM.
```
